### PR TITLE
Update line-jumper.cson with proper selector

### DIFF
--- a/keymaps/line-jumper.cson
+++ b/keymaps/line-jumper.cson
@@ -1,4 +1,4 @@
-'atom-text-editor':
+'atom-text-editor:not([mini])':
   'alt-up': 'line-jumper:move-up'
   'alt-down': 'line-jumper:move-down'
 


### PR DESCRIPTION
The `alt-up` and `alt-down` does not work anymore since Atom now uses these shortcuts for `Select Larger Syntax Node` and `Select Smaller Syntax Node` ([source](https://blog.atom.io/2018/10/23/atom-1-32.html)). These shortcuts were not being overwritten since they use the selector `atom-text-editor:not([mini])` instead of `atom-text-editor`. This change should fix that.